### PR TITLE
Работа с порядковыми числительными.

### DIFF
--- a/pytils/templatetags/pytils_numeral.py
+++ b/pytils/templatetags/pytils_numeral.py
@@ -131,12 +131,35 @@ def in_words(amount, gender=None):
         res = default_value % {'error': err, 'value': str(amount)}
     return res
 
+def in_words_ordinal(amount, gender=None):
+    """
+    In-words representation of amount (ordinal numbers).
+
+    Parameter is a gender: MALE (default), FEMALE or NEUTER
+
+    Examples::
+        {{ some_int|in_words_ordinal }}
+        {{ some_other_int|in_words_ordinal:FEMALE }}
+    """
+    try:
+        ures = numeral.in_words_ordinal(amount, getattr(numeral, str(gender), None))
+        res = pseudo_str(
+                ures,
+                encoding,
+                default_value
+            )
+    except Exception, err:
+        # because filter must die silently
+        res = default_value % {'error': err, 'value': str(amount)}
+    return res
+
 # -- register filters
 
 register.filter('choose_plural', choose_plural)
 register.filter('get_plural', get_plural)
 register.filter('rubles', rubles)
 register.filter('in_words', in_words)
+register.filter('in_words_ordinal', in_words_ordinal)
 
 # -- tags
 


### PR DESCRIPTION
Дополнен numeral.py функциями для порядковых числительных e.g. «первый», «одна тысяча семьсот девяносто третий». Добавлена функция in_words_ordinal и словарь ORDINALS. Также создан соответствующий фильтр для шаблонов джанго.
- 11.09.2011 Исправление опечатки и приведение в соответствие с текущей версией j2a/pytils
