### PR TITLE
Всегда "час назад" вместо "1 час назад", если отсчет идет от текущего момента

### DIFF
--- a/pytils/dt.py
+++ b/pytils/dt.py
@@ -156,8 +156,6 @@ def distance_of_time_in_words(from_time, accuracy=1, to_time=None):
     # альтернативные варианты нужны только если в real_words одно значение
     # и, вдобавок, если используется текущее время
     alter_str = limit == 1 and current and alternatives and \
-                           not (days and hours==1) and \
-                           not (hours and minutes==1) and \
                            alternatives[0]
     _result_str = alter_str or real_str
     result_str = in_future and u"%s %s" % (PREFIX_IN, _result_str) \

--- a/pytils/test/test_dt.py
+++ b/pytils/test/test_dt.py
@@ -27,7 +27,13 @@ class DistanceOfTimeInWordsTestCase(unittest.TestCase):
         self.dtime['10sec_ago'] = _time - 10
         self.dtime['1min_ago'] = _time - 60
         self.dtime['10min_ago'] = _time - 600
-        self.dtime['1hr_ago'] = _time - 3720
+        self.dtime['59min_ago'] = _time - 3540
+        self.dtime['59min59sec_ago'] = _time - 3599
+        self.dtime['1hr_ago'] = _time - 3600
+        self.dtime['1hr1sec_ago'] = _time - 3601
+        self.dtime['1hr59sec_ago'] = _time - 3659
+        self.dtime['1hr1min_ago'] = _time - 3660
+        self.dtime['1hr2min_ago'] = _time - 3720
         self.dtime['10hr_ago'] = _time - 36600
         self.dtime['1day_ago'] = _time - 87600
         self.dtime['1day1hr_ago'] = _time - 90600
@@ -95,7 +101,13 @@ class DistanceOfTimeInWordsTestCase(unittest.TestCase):
         self.ckDefaultAccuracy("10sec_ago", u"менее минуты назад")
         self.ckDefaultAccuracy("1min_ago", u"1 минуту назад")
         self.ckDefaultAccuracy("10min_ago", u"10 минут назад")
+        self.ckDefaultAccuracy("59min_ago", u"59 минут назад")
+        self.ckDefaultAccuracy("59min59sec_ago", u"59 минут назад")
         self.ckDefaultAccuracy("1hr_ago", u"1 час назад")
+        self.ckDefaultAccuracy("1hr1sec_ago", u"1 час назад")
+        self.ckDefaultAccuracy("1hr59sec_ago", u"1 час назад")
+        self.ckDefaultAccuracy("1hr1min_ago", u"1 час назад")
+        self.ckDefaultAccuracy("1hr2min_ago", u"1 час назад")
         self.ckDefaultAccuracy("10hr_ago", u"10 часов назад")
         self.ckDefaultAccuracy("1day_ago", u"1 день назад")
         self.ckDefaultAccuracy("1day1hr_ago", u"1 день назад")
@@ -111,12 +123,21 @@ class DistanceOfTimeInWordsTestCase(unittest.TestCase):
         self.ckDefaultAccuracy("in_2day", u"через 2 дня")
 
     def testDOTIWDefaultAccuracyDayAndMinute(self):
+        """
+        Unit-tests for distance_of_time_in_words with default accuracy and to_time
+        """
         self.ckDefaultTimeAndAccuracy("4day1min_ago", u"4 дня назад")
 
         self.ckDefaultTimeAndAccuracy("10sec_ago", u"менее минуты назад")
         self.ckDefaultTimeAndAccuracy("1min_ago", u"минуту назад")
         self.ckDefaultTimeAndAccuracy("10min_ago", u"10 минут назад")
+        self.ckDefaultTimeAndAccuracy("59min_ago", u"59 минут назад")
+        self.ckDefaultTimeAndAccuracy("59min59sec_ago", u"59 минут назад")
         self.ckDefaultTimeAndAccuracy("1hr_ago", u"час назад")
+        self.ckDefaultTimeAndAccuracy("1hr1sec_ago", u"час назад")
+        self.ckDefaultTimeAndAccuracy("1hr59sec_ago", u"час назад")
+        self.ckDefaultTimeAndAccuracy("1hr1min_ago", u"час назад")
+        self.ckDefaultTimeAndAccuracy("1hr2min_ago", u"час назад")
         self.ckDefaultTimeAndAccuracy("10hr_ago", u"10 часов назад")
         self.ckDefaultTimeAndAccuracy("1day_ago", u"вчера")
         self.ckDefaultTimeAndAccuracy("1day1hr_ago", u"вчера")
@@ -148,7 +169,13 @@ class DistanceOfTimeInWordsTestCase(unittest.TestCase):
         self.ckDefaultToTime("10sec_ago", 1, u"менее минуты назад")
         self.ckDefaultToTime("1min_ago", 1, u"минуту назад")
         self.ckDefaultToTime("10min_ago", 1,  u"10 минут назад")
+        self.ckDefaultToTime("59min_ago", 1, u"59 минут назад")
+        self.ckDefaultToTime("59min59sec_ago", 1, u"59 минут назад")
         self.ckDefaultToTime("1hr_ago", 1, u"час назад")
+        self.ckDefaultToTime("1hr1sec_ago", 1, u"час назад")
+        self.ckDefaultToTime("1hr59sec_ago", 1, u"час назад")
+        self.ckDefaultToTime("1hr1min_ago", 1, u"час назад")
+        self.ckDefaultToTime("1hr2min_ago", 1, u"час назад")
         self.ckDefaultToTime("10hr_ago", 1, u"10 часов назад")
         self.ckDefaultToTime("1day_ago", 1, u"вчера")
         self.ckDefaultToTime("1day1hr_ago", 1, u"вчера")
@@ -171,7 +198,13 @@ class DistanceOfTimeInWordsTestCase(unittest.TestCase):
         self.ckDefaultToTime("10sec_ago", 2, u"менее минуты назад")
         self.ckDefaultToTime("1min_ago", 2, u"минуту назад")
         self.ckDefaultToTime("10min_ago", 2,  u"10 минут назад")
-        self.ckDefaultToTime("1hr_ago", 2, u"1 час 2 минуты назад")
+        self.ckDefaultToTime("59min_ago", 2, u"59 минут назад")
+        self.ckDefaultToTime("59min59sec_ago", 2, u"59 минут назад")
+        self.ckDefaultToTime("1hr_ago", 2, u"час назад")
+        self.ckDefaultToTime("1hr1sec_ago", 2, u"час назад")
+        self.ckDefaultToTime("1hr59sec_ago", 2, u"час назад")
+        self.ckDefaultToTime("1hr1min_ago", 2, u"1 час 1 минуту назад")
+        self.ckDefaultToTime("1hr2min_ago", 2, u"1 час 2 минуты назад")
         self.ckDefaultToTime("10hr_ago", 2, u"10 часов 10 минут назад")
         self.ckDefaultToTime("1day_ago", 2, u"вчера")
         self.ckDefaultToTime("1day1hr_ago", 2, u"1 день 1 час назад")
@@ -194,7 +227,13 @@ class DistanceOfTimeInWordsTestCase(unittest.TestCase):
         self.ckDefaultToTime("10sec_ago", 3, u"менее минуты назад")
         self.ckDefaultToTime("1min_ago", 3, u"минуту назад")
         self.ckDefaultToTime("10min_ago", 3,  u"10 минут назад")
-        self.ckDefaultToTime("1hr_ago", 3, u"1 час 2 минуты назад")
+        self.ckDefaultToTime("59min_ago", 3, u"59 минут назад")
+        self.ckDefaultToTime("59min59sec_ago", 3, u"59 минут назад")
+        self.ckDefaultToTime("1hr_ago", 3, u"час назад")
+        self.ckDefaultToTime("1hr1sec_ago", 3, u"час назад")
+        self.ckDefaultToTime("1hr59sec_ago", 3, u"час назад")
+        self.ckDefaultToTime("1hr1min_ago", 3, u"1 час 1 минуту назад")
+        self.ckDefaultToTime("1hr2min_ago", 3, u"1 час 2 минуты назад")
         self.ckDefaultToTime("10hr_ago", 3, u"10 часов 10 минут назад")
         self.ckDefaultToTime("1day_ago", 3,
                                 u"1 день 0 часов 20 минут назад")


### PR DESCRIPTION
Бага https://github.com/j2a/pytils/issues/3
- если отсчет времени идет от текущего момента, то для промежутка времени 1ч00м указывалось "час назад", для времени от 1ч01м до 1ч59м - "1 час назад". Теперь всегда в таких случаях указывается "час назад";
- добавил дополнительные тесты на это.
