### PR TITLE
[numeral] Removed excessive space after 'ноль'

### DIFF
--- a/pytils/numeral.py
+++ b/pytils/numeral.py
@@ -360,7 +360,10 @@ def sum_string(amount, gender, items=None):
     check_positive(amount)
 
     if amount == 0:
-        return u"ноль %s" % five_items
+        if five_items:
+            return u"ноль %s" % five_items
+        else:
+            return u"ноль"
 
     into = u''
     tmp_val = amount

--- a/pytils/test/test_numeral.py
+++ b/pytils/test/test_numeral.py
@@ -220,6 +220,7 @@ class InWordsTestCase(unittest.TestCase):
         """
         Unit-test for in_words_int
         """
+        self.assertEquals(pytils.numeral.in_words_int(0), u"ноль")
         self.assertEquals(pytils.numeral.in_words_int(10), u"десять")
         self.assertEquals(pytils.numeral.in_words_int(5), u"пять")
         self.assertEquals(pytils.numeral.in_words_int(102), u"сто два")


### PR DESCRIPTION
in case there is no 'items' (word forms) specified