### PR TITLE
publish a wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ publish: build
 	twine upload dist/*
 
 build: clean
-	python setup.py sdist
+	python -m build
 
 clean:
 	rm -rf dist


### PR DESCRIPTION
This project currently publishes only a source distribution, so every user has to build a wheel for themselves. This is slower and can go wrong.

Better for package maintainers to build and publish a wheel once and for all.

You will need to `pip install build` to run the build command (just as you need to `pip install twine` to run the publish command)